### PR TITLE
✨feat: 비밀번호 확인 API 추가

### DIFF
--- a/src/main/java/com/WealthTracker/demo/DTO/PasswordConfirmDTO.java
+++ b/src/main/java/com/WealthTracker/demo/DTO/PasswordConfirmDTO.java
@@ -1,0 +1,18 @@
+package com.WealthTracker.demo.DTO;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PasswordConfirmDTO {
+    @NotNull
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$\n")
+    private String confirmPassword; // 확인할 비밀번호
+}

--- a/src/main/java/com/WealthTracker/demo/constants/SuccessCode.java
+++ b/src/main/java/com/WealthTracker/demo/constants/SuccessCode.java
@@ -18,7 +18,8 @@ public enum SuccessCode {
     SUCCESS_LOGIN(200, "로그인을 성공했습니다."),
     SUCCESS_EXPEND_INCOME(200,"지출과 수입 내역을 성공적으로 불러왔습니다."),
     SUCCESS_RESET_CODE_SENT(200, "비밀번호 재설정 코드가 발송되었습니다."),
-    SUCCESS_PASSWORD_RESET(200, "비밀번호가 성공적으로 재설정되었습니다.");
+    SUCCESS_PASSWORD_RESET(200, "비밀번호가 성공적으로 재설정되었습니다."),
+    SUCCESS_PASSWORD_CONFIRM(200, "비밀번호 확인이 완료되었습니다.");
     private final int status;
     private final String message;
 

--- a/src/main/java/com/WealthTracker/demo/controller/AuthController.java
+++ b/src/main/java/com/WealthTracker/demo/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.WealthTracker.demo.controller;
 
+import com.WealthTracker.demo.DTO.PasswordConfirmDTO;
 import com.WealthTracker.demo.DTO.VerificationCodeConfirmDTO;
 import com.WealthTracker.demo.DTO.VerificationCodeRequestDTO;
 import com.WealthTracker.demo.DTO.SignupRequestDTO;
@@ -48,6 +49,18 @@ public class AuthController { //** Signup 및 EmailAuth 담당 Controller **//
             return ResponseEntity.ok(SuccessCode.EMAIL_VERIFIED.getMessage());
         } catch (CustomException e) {
             return ResponseEntity.badRequest().body(ErrorCode.INVALID_VERIFICATION_CODE.getMessage());
+        }
+    }
+
+    //* 비밀번호 확인
+    @PostMapping("/confirm-password")
+    public ResponseEntity<?> confirmPassword(@RequestHeader("Authorization") String token,
+                                             @RequestBody PasswordConfirmDTO passwordConfirmDTO) {
+        try {
+            signupService.confirmPassword(token, passwordConfirmDTO);
+            return ResponseEntity.ok(SuccessCode.SUCCESS_PASSWORD_CONFIRM.getMessage());
+        } catch (CustomException e) {
+            return ResponseEntity.badRequest().body(ErrorCode.PASSWORD_MISMATCH.getMessage());
         }
     }
 

--- a/src/main/java/com/WealthTracker/demo/service/SignupService.java
+++ b/src/main/java/com/WealthTracker/demo/service/SignupService.java
@@ -1,5 +1,6 @@
 package com.WealthTracker.demo.service;
 
+import com.WealthTracker.demo.DTO.PasswordConfirmDTO;
 import com.WealthTracker.demo.DTO.SignupRequestDTO;
 import com.WealthTracker.demo.domain.User;
 
@@ -16,6 +17,8 @@ public interface SignupService {
     String createVerificationCodeAndSendEmail(String email); // 새로운 인증코드 생성
 
     void verifyEmail(String email, String code); // 이메일 인증코드 검증
+
+    String confirmPassword(String token, PasswordConfirmDTO passwordConfirmDTO); // 비밀번호 확인 메서드
 
     void createPasswordResetCode(String email);  // 비밀번호 재설정 코드 생성
 

--- a/src/main/java/com/WealthTracker/demo/service/SignupServiceImpl.java
+++ b/src/main/java/com/WealthTracker/demo/service/SignupServiceImpl.java
@@ -1,5 +1,6 @@
 package com.WealthTracker.demo.service;
 
+import com.WealthTracker.demo.DTO.PasswordConfirmDTO;
 import com.WealthTracker.demo.DTO.SignupRequestDTO;
 import com.WealthTracker.demo.constants.ErrorCode;
 import com.WealthTracker.demo.constants.SuccessCode;
@@ -8,6 +9,7 @@ import com.WealthTracker.demo.domain.VerificationCode;
 import com.WealthTracker.demo.error.CustomException;
 import com.WealthTracker.demo.repository.UserRepository;
 import com.WealthTracker.demo.repository.VerificationCodeRepository;
+import com.WealthTracker.demo.util.JwtUtil;
 import com.WealthTracker.demo.util.VerificationCodeUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,6 +28,7 @@ public class SignupServiceImpl implements SignupService {
     private final PasswordEncoder passwordEncoder;
     private final EmailService emailService;
     private final VerificationCodeUtil verificationCodeUtil;
+    private final JwtUtil jwtUtil;
 
     @Override
     @Transactional
@@ -70,6 +73,22 @@ public class SignupServiceImpl implements SignupService {
         } catch (CustomException e) {
             throw new CustomException(ErrorCode.EMAIL_VERIFY_FAIL);
         }
+    }
+
+    @Override
+    @Transactional
+    public String confirmPassword(String token, PasswordConfirmDTO passwordConfirmDTO) {
+        Optional<User> user = userRepository.findByUserId(jwtUtil.getUserId(token));
+        User myUser = user.orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        ); // 기존 유저의 비밀번호를 확인하기 위해 로그인한 유저의 정보를 가져와야함.
+
+        if (!passwordEncoder.matches(passwordConfirmDTO.getConfirmPassword(), myUser.getPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH); // 기존 비밀번호와 일치하지 않는 경우에 오류 던지기
+        }
+        // 일치하는 경우에 밑의 로직 실행하면 됨
+
+        return SuccessCode.SUCCESS_PASSWORD_CONFIRM.getMessage();
     }
 
     @Override


### PR DESCRIPTION
### 주요 구현 기능

- 간단하게 로그인 한 유저의 비밀번호와 `JSON`으로 입력받은 유저의 비밀번호가 일치하는 경우 `SUCCESS`
- 토큰에서 추출한 유저의 ID를 기반으로 `PasswordEncoder`를 통해 기존 비밀번호와 `Match`
- 로직에서 발생 가능한 예외 처리 구현

## 어떠한 기능에 `API`가 사용이 되는가 ?  ➡  비밀번호 정보 변경 시 기존 비밀번호를 확인할 때 필요한 `API`

### 주요 구현 코드

## Controller
```java
//* 비밀번호 확인
    @PostMapping("/confirm-password")
    public ResponseEntity<?> confirmPassword(@RequestHeader("Authorization") String token,
                                             @RequestBody PasswordConfirmDTO passwordConfirmDTO) {
        try {
            signupService.confirmPassword(token, passwordConfirmDTO);
            return ResponseEntity.ok(SuccessCode.SUCCESS_PASSWORD_CONFIRM.getMessage());
        } catch (CustomException e) {
            return ResponseEntity.badRequest().body(ErrorCode.PASSWORD_MISMATCH.getMessage());
        }
    }
```

## DTO
```java
public class PasswordConfirmDTO {
    @NotNull
    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$\n")
    private String confirmPassword; // 확인할 비밀번호
}
```

## ServiceImpl
```java
@Override
    @Transactional
    public String confirmPassword(String token, PasswordConfirmDTO passwordConfirmDTO) {
        Optional<User> user = userRepository.findByUserId(jwtUtil.getUserId(token));
        User myUser = user.orElseThrow(
                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
        ); // 기존 유저의 비밀번호를 확인하기 위해 로그인한 유저의 정보를 가져와야함.

        if (!passwordEncoder.matches(passwordConfirmDTO.getConfirmPassword(), myUser.getPassword())) {
            throw new CustomException(ErrorCode.PASSWORD_MISMATCH); // 기존 비밀번호와 일치하지 않는 경우에 오류 던지기
        }
        // 일치하는 경우에 밑의 로직 실행하면 됨

        return SuccessCode.SUCCESS_PASSWORD_CONFIRM.getMessage();
    }
```